### PR TITLE
Refactor UI and enhance memory management

### DIFF
--- a/ImageSource Memory Leak/AppShell.xaml
+++ b/ImageSource Memory Leak/AppShell.xaml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Shell
-    x:Class="ImageSource_Memory_Leak.AppShell"
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:ImageSource_Memory_Leak"
-    Shell.FlyoutBehavior="Disabled"
-    Title="ImageSource_Memory_Leak">
+	x:Class="ImageSource_Memory_Leak.AppShell"
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:ImageSource_Memory_Leak"
+	Title="ImageSource_Memory_Leak"
+	Shell.FlyoutBehavior="Disabled">
 
-    <ShellContent
-        Title="Home"
-        ContentTemplate="{DataTemplate local:MainPage}"
-        Route="MainPage" />
+	<ShellContent
+		Title="Home"
+		ContentTemplate="{DataTemplate local:FirstPage}"
+		Route="MainPage" />
 
 </Shell>

--- a/ImageSource Memory Leak/ImageSource Memory Leak.csproj
+++ b/ImageSource Memory Leak/ImageSource Memory Leak.csproj
@@ -18,7 +18,7 @@
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
+		<Nullable>disable</Nullable>
 
 		<!-- Display name -->
 		<ApplicationTitle>ImageSource Memory Leak</ApplicationTitle>

--- a/ImageSource Memory Leak/MainPage.xaml.cs
+++ b/ImageSource Memory Leak/MainPage.xaml.cs
@@ -5,11 +5,50 @@ using System.Threading;
 
 namespace ImageSource_Memory_Leak
 {
-    public partial class MainPage : ContentPage
-    {
-        public MainPage()
-        {
-            InitializeComponent();
-        }
-    }
+	public partial class MainPage : ContentPage
+	{
+		public MainPage()
+		{
+			InitializeComponent();
+		}
+
+		protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
+		{
+			FirstPage.FullGC();
+			FirstPage.FullGC();
+		}
+	}
+
+	sealed class FirstPage : ContentPage
+	{
+		public FirstPage()
+		{
+			var btn = new Button
+			{
+				Text = "Navigate",
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			btn.Clicked += async (_, __) =>
+			{
+				FullGC();
+				await Shell.Current.Navigation.PushAsync(new MainPage());
+			};
+
+			Content = btn;
+		}
+
+
+
+
+		public static void FullGC()
+		{
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+		}
+	}
 }
+
+

--- a/ImageSource Memory Leak/MainPageViewModel.cs
+++ b/ImageSource Memory Leak/MainPageViewModel.cs
@@ -11,100 +11,112 @@ using Microsoft.Maui.Controls;
 
 namespace ImageSource_Memory_Leak
 {
-    public partial class MainPageViewModel : ObservableObject
-    {
-        private Timer _timer; // Timer to periodically update the image
+	public partial class MainPageViewModel : ObservableObject
+	{
+		private WeakReference<Timer> _timer; // Timer to periodically update the image
 
-        // Observable property to hold the current image source
-        [ObservableProperty]
-        private ImageSource _cameraImage;
+		public Timer Timer
+		{
+			get => _timer.TryGetTarget(out var timer) ? timer : null;
+			set => _timer = new(value);
 
-        // Field to store the frame data byte array
-        private byte[] _frameData;
+		}
 
-        public MainPageViewModel()
-        {
-            // Start updating the image when the view model is instantiated
-            StartImageUpdate();
-        }
+		// Observable property to hold the current image source
+		[ObservableProperty]
+		private ImageSource _cameraImage;
 
-        private void StartImageUpdate()
-        {
-            // Initialize and start the timer to update the image 60 times per second (1000ms / 60 ≈ 16.67ms)
-            _timer = new Timer(UpdateImage, null, 0, 1000 / 60);
-        }
+		// Field to store the frame data byte array
+		private byte[] _frameData;
 
-        private void UpdateImage(object state)
-        {
-            // Generate random image byte array
-            byte[] imageData = ImageGenerator.GenerateRandomImage();
+		public MainPageViewModel()
+		{
+			// Start updating the image when the view model is instantiated
+			StartImageUpdate();
+		}
 
-            // Update the Image control on the main thread
-            _frameData = imageData; // Store the frame data
+		private void StartImageUpdate()
+		{
+			// Initialize and start the timer to update the image 60 times per second (1000ms / 60 ≈ 16.67ms)
+			Timer = new Timer(UpdateImage, null, 0, 1000 / 60);
+		}
 
-            // Create a new StreamImageSource from the frame data
-            var streamImageSource = new StreamImageSource
-            {
-                Stream = token =>
-                {
-                    // Create a MemoryStream from the frame data
-                    MemoryStream memoryStream = new MemoryStream(_frameData);
-                    _frameData = null; // Clear the frame data after creating the stream to release memory
-                    return Task.FromResult<Stream>(memoryStream);
-                }
-            };
+		private void UpdateImage(object state)
+		{
+			// Generate random image byte array
+			byte[] imageData = ImageGenerator.GenerateRandomImage();
 
-            // Assign the new StreamImageSource to the CameraImage property to update the UI
-            CameraImage = streamImageSource;
-        }
-        // Destructor to clean up the timer when the view model is destroyed
-        ~MainPageViewModel()
-        {
-            _timer?.Dispose(); // Dispose the timer to stop updates
-        }
-    }
+			// Update the Image control on the main thread
+			_frameData = imageData; // Store the frame data
 
-    public class ImageGenerator
-    {
-        /// <summary>
-        /// Generates a random byte array representing a 500x500 pixel image in JPEG format.
-        /// </summary>
-        /// <returns>A byte array representing the image.</returns>
-        public static byte[] GenerateRandomImage()
-        {
-            int width = 500; // Width of the image
-            int height = 500; // Height of the image
+			// Create a new StreamImageSource from the frame data
+			var streamImageSource = new StreamImageSource
+			{
+				Stream = token =>
+				{
+					// Create a MemoryStream from the frame data
+					MemoryStream memoryStream = new MemoryStream(_frameData);
+					_frameData = null; // Clear the frame data after creating the stream to release memory
+					return Task.FromResult<Stream>(memoryStream);
+				}
+			};
 
-            // Create an empty bitmap with SkiaSharp
-            using (var bitmap = new SKBitmap(width, height))
-            {
-                var random = new Random(); // Random number generator for pixel colors
+			// Assign the new StreamImageSource to the CameraImage property to update the UI
+			CameraImage = streamImageSource;
+		}
+		// Destructor to clean up the timer when the view model is destroyed
+		~MainPageViewModel()
+		{
 
-                // Generate random pixels for the bitmap
-                for (int y = 0; y < height; y++)
-                {
-                    for (int x = 0; x < width; x++)
-                    {
-                        // Create a random color
-                        var randomColor = new SKColor(
-                            (byte)random.Next(256), // Red component (0-255)
-                            (byte)random.Next(256), // Green component (0-255)
-                            (byte)random.Next(256)  // Blue component (0-255)
-                        );
+			// Some times when you navigate from the Mainpage, the breakpoint wouldn't be hitten
+			// but if you take a snapshot there's no reference to this type... I belive that's expected
+			// Because Finalizers are called from a specific thread and the debugger could get lost, or 
+			// it's just a bug, who knows? ¯\(ツ)/¯
+			Timer?.Dispose(); // Dispose the timer to stop updates
+		}
+	}
 
-                        // Set the pixel color in the bitmap
-                        bitmap.SetPixel(x, y, randomColor);
-                    }
-                }
+	public class ImageGenerator
+	{
+		/// <summary>
+		/// Generates a random byte array representing a 500x500 pixel image in JPEG format.
+		/// </summary>
+		/// <returns>A byte array representing the image.</returns>
+		public static byte[] GenerateRandomImage()
+		{
+			int width = 500; // Width of the image
+			int height = 500; // Height of the image
 
-                // Create an image from the bitmap and encode it to JPEG format
-                using (var image = SKImage.FromBitmap(bitmap))
-                using (var data = image.Encode(SKEncodedImageFormat.Jpeg, 100))
-                {
-                    // Return the encoded image as a byte array
-                    return data.ToArray();
-                }
-            }
-        }
-    }
+			// Create an empty bitmap with SkiaSharp
+			using (var bitmap = new SKBitmap(width, height))
+			{
+				var random = new Random(); // Random number generator for pixel colors
+
+				// Generate random pixels for the bitmap
+				for (int y = 0; y < height; y++)
+				{
+					for (int x = 0; x < width; x++)
+					{
+						// Create a random color
+						var randomColor = new SKColor(
+							(byte)random.Next(256), // Red component (0-255)
+							(byte)random.Next(256), // Green component (0-255)
+							(byte)random.Next(256)  // Blue component (0-255)
+						);
+
+						// Set the pixel color in the bitmap
+						bitmap.SetPixel(x, y, randomColor);
+					}
+				}
+
+				// Create an image from the bitmap and encode it to JPEG format
+				using (var image = SKImage.FromBitmap(bitmap))
+				using (var data = image.Encode(SKEncodedImageFormat.Jpeg, 100))
+				{
+					// Return the encoded image as a byte array
+					return data.ToArray();
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
- Updated AppShell.xaml to load `FirstPage` as the initial page, with minor formatting adjustments.
- Disabled nullable reference types in the project file to change compiler nullability checks.
- Added `OnNavigatedFrom` in MainPage.xaml.cs to force garbage collection when navigating away, and introduced a new `FirstPage` class with a method to explicitly call garbage collection.
- MainPageViewModel.cs now uses a `WeakReference<Timer>` for better memory management, added a new `Timer` property for encapsulated access, and updated the destructor with a comment on finalizer execution.
- Minor unchanged functionality in `ImageGenerator` class, indicating a focus on memory management and performance improvements.
